### PR TITLE
Use .env file for api key

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,14 @@ Simple toggl.com time tracker widget that shows currently running project and ti
 
 Similar to official dock widget for macOS, but for polybar/i3bar/etc.
 
+## Requirements
+* Python3
+* python-dotenv ```python3 -m pip install python-dotenv```
+
+## API Key
+This script requires a toggl api key. These are attached to each toggl user, and instructions for finding it are [here](https://github.com/toggl/toggl_api_docs#api-token).
+
+Put your api key into the file ```togglapi.env``` - and *make sure this is in your .gitignore if you have a dotfiles repository*.
 
 ## Screenshots
 ![screenshot](https://github.com/maksmeshkov/toggl_polybar/blob/master/screenshot.png "This is how it looks")

--- a/toggl.py
+++ b/toggl.py
@@ -1,6 +1,18 @@
+#!/usr/bin/env python3
 import time, requests, json
+from dotenv import load_dotenv
+from os import getenv
+from pathlib import Path
 
-api_token = "" # Paste your API token here
+# Get API token from .env file
+env_path = pathlib.Path(__file__).parent.absolute() / 'togglapi.env'
+load_dotenv(dotenv_path=env_path)
+api_token = getenv("TOGGL_API_KEY")
+
+if(api_token == None):
+    print("API token empty")
+    exit()
+    
 current = json.loads(
     requests.get("https://www.toggl.com/api/v8/time_entries/current", auth=(api_token, "api_token")).content)
 if current['data'] is not None and ("pid" in current["data"] or "description" in current["data"]):
@@ -20,4 +32,4 @@ if current['data'] is not None and ("pid" in current["data"] or "description" in
     out = name + " " + '(' + h + ':' + m + ')'
     print(out)
 else:
-    print("No project is running")
+    print("No project")

--- a/togglapi.env
+++ b/togglapi.env
@@ -1,0 +1,1 @@
+TOGGL_API_KEY=<put your api key here>


### PR DESCRIPTION
This is my first pull request ever & is just to change the hard-coded api key to a .env file so it doesn't accidentally get leaked so easily.

I also added a little description on how to find your api key, and a shebang to the top of the script so that it uses the right interpreter every time :)